### PR TITLE
Add scheduled trigger for Docker build workflow

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main # Trigger workflow on pull request to main branch (adjust as needed)
+  schedule:
+    - cron: '0 * * * *' # Trigger workflow every hour
 
 jobs:
   build-and-push:


### PR DESCRIPTION
Signed-off-by: yukuai0011 <kuyu5570@uni.sydney.edu.au>

## Summary by Sourcery

Add a scheduled trigger to the Docker build workflow to ensure it runs every hour, enhancing automation and consistency in the build process.

CI:
- Add a scheduled trigger to the Docker build workflow to run every hour using a cron expression.