### PR TITLE
build as whenever it is possible

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -8,11 +8,15 @@ on:
     branches:
       - main # Trigger workflow on pull request to main branch (adjust as needed)
   schedule:
-    - cron: '0 * * * *' # Trigger workflow every hour
+    - cron: '* * * * *' # Trigger workflow every minute (adjust as needed)
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+
+    concurrency:
+      group: docker-build
+      cancel-in-progress: false
 
     steps:
       # Step 1: Checkout the repository

--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main # Trigger workflow on pull request to main branch (adjust as needed)
+  schedule:
+    - cron: '0 * * * *' # Trigger workflow every hour
 
 jobs:
   build-and-push:


### PR DESCRIPTION
Signed-off-by: yukuai0011 <kuyu5570@uni.sydney.edu.au>

## Summary by Sourcery

Update the CI workflow to include a cron schedule for frequent triggering and add concurrency control to manage build jobs.

CI:
- Add a cron schedule to trigger the workflow every minute.
- Introduce concurrency control for the build-and-push job with a group named 'docker-build' and disable cancel-in-progress.