### PR TITLE
fix: specify ref in checkout step of Docker workflow

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -18,6 +18,8 @@ jobs:
       # Step 1: Checkout the repository
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }} 
 
       # Step 2: Log in to Docker Hub
       - name: Log in to Docker Hub


### PR DESCRIPTION
Signed-off-by: yukuai0011 <kuyu5570@uni.sydney.edu.au>

## Summary by Sourcery

Specify the ref in the checkout step of the Docker workflow to ensure the correct branch or tag is checked out.

CI:
- Specify the ref in the checkout step of the Docker workflow to ensure the correct branch or tag is checked out.