### PR TITLE
fix: update GitHub Actions workflow to use latest action versions without specific tags, because I do not have time to maintain this project

### DIFF
--- a/.github/workflows/build_docker.yaml
+++ b/.github/workflows/build_docker.yaml
@@ -17,24 +17,24 @@ jobs:
     steps:
       # Step 1: Checkout the repository
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout
         with:
           ref: ${{ github.ref }} 
 
       # Step 2: Log in to Docker Hub
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Step 3: Set up Docker Buildx (for better compatibility and multi-platform support)
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action
 
       # Step 4: Build and push the Docker image
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action
         with:
           context: . # Path to the Dockerfile
           push: true # Push the image after building


### PR DESCRIPTION
Signed-off-by: yukuai0011 <kuyu5570@uni.sydney.edu.au>

## Summary by Sourcery

CI:
- Update GitHub Actions workflow to use the latest versions of actions without specific tags for checkout, login, setup-buildx, and build-push.